### PR TITLE
Tabs: Fix Arrow Rendering

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/Tabs/index.js
@@ -141,14 +141,14 @@ function ResponseCodeTabs(props) {
   };
 
   const tabItemListContainerRef = useRef(null);
-  const shouldRenderArrows = values.length > 6;
+  const showTabArrows = values.length > 5;
 
   const handleRightClick = () => {
-    tabItemListContainerRef.current.scrollLeft += 75;
+    tabItemListContainerRef.current.scrollLeft += 90;
   };
 
   const handleLeftClick = () => {
-    tabItemListContainerRef.current.scrollLeft -= 75;
+    tabItemListContainerRef.current.scrollLeft -= 90;
   };
 
   return (
@@ -156,7 +156,7 @@ function ResponseCodeTabs(props) {
       <div className={styles.responseTabsTopSection}>
         <strong>Responses</strong>
         <div className={styles.responseTabsContainer}>
-          {shouldRenderArrows && (
+          {showTabArrows && (
             <button
               className={clsx(styles.tabArrow, styles.tabArrowLeft)}
               onClick={handleLeftClick}
@@ -209,7 +209,7 @@ function ResponseCodeTabs(props) {
               );
             })}
           </ul>
-          {shouldRenderArrows && (
+          {showTabArrows && (
             <button
               className={clsx(styles.tabArrow, styles.tabArrowRight)}
               onClick={handleRightClick}

--- a/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
@@ -37,7 +37,8 @@
 }
 
 .responseTabsListContainer {
-  max-width: 450px;
+  max-width: 440px;
+  padding: 0 0.25rem;
   overflow-y: hidden;
   overflow-x: scroll;
   scroll-behavior: smooth;


### PR DESCRIPTION
## Description

* Modify Tabs component and styling to render arrows (more than 5 response code tabs) and prevent button clipping.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/48506502/157128666-c10187b0-a7ad-4b01-beb8-4ca29eb27a0c.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
