### PR TITLE
UI Cleanup: Response code tabs & schema indentation

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -123,6 +123,7 @@ function createRows({ schema }: RowsProps): string | undefined {
   // object
   if (schema.properties !== undefined) {
     return create("div", {
+      style: { marginLeft: "16px" },
       children: create("div", {
         children: Object.entries(schema.properties).map(([key, val]) =>
           createRow({

--- a/packages/docusaurus-theme-openapi/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/Tabs/index.js
@@ -176,12 +176,12 @@ function ResponseCodeTabs(props) {
             )}
           >
             {values.map(({ value, label, attributes }) => {
-              const tabStyle =
+              const responseTabDotStyle =
                 parseInt(value) >= 400
-                  ? styles.responseTabDanger
+                  ? styles.responseTabDotDanger
                   : parseInt(value) >= 200 && parseInt(value) < 300
-                  ? styles.responseTabSuccess
-                  : styles.responseTabInfo;
+                  ? styles.responseTabDotSuccess
+                  : styles.responseTabDotInfo;
 
               return (
                 <li
@@ -198,12 +198,14 @@ function ResponseCodeTabs(props) {
                     "tabs__item",
                     styles.tabItem,
                     attributes?.className,
-                    tabStyle,
                     {
                       [styles.responseTabActive]: selectedValue === value,
                     }
                   )}
                 >
+                  <div
+                    className={clsx(styles.responseTabDot, responseTabDotStyle)}
+                  />
                   {label ?? value}
                 </li>
               );

--- a/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
@@ -13,11 +13,15 @@
   height: 2.5rem;
   margin-top: 0 !important;
   margin-right: 0.5rem;
-  padding: 1rem;
-  font-weight: var(--ifm-font-weight-normal);
   border: 1px solid var(--openapi-code-dim-dark);
   border-radius: var(--ifm-global-radius);
+  padding: 1rem;
+  font-weight: var(--ifm-font-weight-normal);
   color: var(--openapi-code-dim-dark);
+}
+
+.tabItem:hover {
+  color: var(--ifm-color-emphasis-500) !important;
 }
 
 .tabItem:last-child {
@@ -49,33 +53,28 @@
 }
 
 /* Response Code Tabs - Colored Dots */
-.responseTabSuccess::before,
-.responseTabDanger::before,
-.responseTabInfo::before {
-  padding: 0.25rem 0.25rem 0 0;
-  font-size: 3.5rem;
-  content: "•";
+.responseTabDot {
+  width: 12.5px;
+  height: 12.5px;
+  margin-right: 5px;
+  border-radius: 50%;
 }
 
-.responseTabSuccess::before {
-  color: var(--ifm-color-success);
-}
-.responseTabDanger::before {
-  color: var(--ifm-color-danger);
-}
-.responseTabInfo::before {
-  color: var(--ifm-color-info);
+.responseTabDotSuccess {
+  background-color: var(--ifm-color-success);
 }
 
-.responseTabSuccess:hover,
-.responseTabDanger:hover,
-.responseTabInfo:hover {
-  color: var(--ifm-color-emphasis-500) !important;
+.responseTabDotDanger {
+  background-color: var(--ifm-color-danger);
+}
+
+.responseTabDotInfo {
+  background-color: var(--ifm-color-info);
 }
 
 .responseTabActive {
-  border: 1px solid var(--ifm-color-primary) !important;
-  color: var(--ifm-color-primary) !important;
+  border: 1px solid var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
 }
 
 .responseSchemaContainer {


### PR DESCRIPTION
## Description

* Use styled `<div/>` for response code tab dots
* Add indentation to nested schema levels

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
<img width="643" alt="image" src="https://user-images.githubusercontent.com/48506502/157357734-9747efdc-f771-4655-a5a4-4349d864132a.png">


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
