### PR TITLE
UI Cleanup: Schema Indentation | Updated Summary Marker | Tabs

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
@@ -38,7 +38,7 @@ export function createParamsDetails({ parameters, type }: Props) {
       create("div", {
         children: params.map((param) =>
           create("div", {
-            style: { marginLeft: "16px" },
+            style: { marginLeft: "1.5rem" },
             children: [
               create("strong", { children: param.name }),
               guard(param.schema, (schema) =>

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -66,13 +66,13 @@ function createRow({ name, schema, required }: RowProps) {
           children: [
             guard(getQualifierMessage(schema), (message) =>
               create("div", {
-                style: { marginLeft: "16px" },
+                style: { marginLeft: "1.5rem" },
                 children: createDescription(message),
               })
             ),
             guard(schema.description, (description) =>
               create("div", {
-                style: { marginLeft: "16px" },
+                style: { marginLeft: "1.5rem" },
                 children: createDescription(description),
               })
             ),
@@ -123,7 +123,7 @@ function createRows({ schema }: RowsProps): string | undefined {
   // object
   if (schema.properties !== undefined) {
     return create("div", {
-      style: { marginLeft: "16px" },
+      style: { marginLeft: "1.5rem" },
       children: create("div", {
         children: Object.entries(schema.properties).map(([key, val]) =>
           createRow({
@@ -144,7 +144,7 @@ function createRows({ schema }: RowsProps): string | undefined {
     return create("div", {
       className: "allOf",
       style: {
-        marginLeft: "16px",
+        marginLeft: "1.5rem",
       },
       children: create("div", {
         children: Object.entries(properties).map(([key, val]) =>
@@ -201,13 +201,7 @@ function createRowsRoot({ schema }: RowsRootProps) {
   if (schema.items !== undefined) {
     return create("div", {
       children: create("div", {
-        children: [
-          create("span", {
-            style: { opacity: "0.6" },
-            children: ` ${getSchemaName(schema, true)}`,
-          }),
-          createRows({ schema: schema.items }),
-        ],
+        children: [createRows({ schema: schema.items })],
       }),
     });
   }
@@ -272,6 +266,10 @@ export function createSchemaDetails({ title, body, ...rest }: Props) {
     }
   }
 
+  const firstBodyIndentation = firstBody.items
+    ? { marginLeft: "0" }
+    : { marginLeft: "1.5rem" };
+
   return createDetails({
     ...rest,
     children: [
@@ -291,7 +289,7 @@ export function createSchemaDetails({ title, body, ...rest }: Props) {
         ],
       }),
       create("div", {
-        style: { marginLeft: "16px" },
+        style: { marginLeft: "1.5rem" },
         children: create("div", {
           children: create("div", {
             style: { textAlign: "left" },
@@ -304,7 +302,7 @@ export function createSchemaDetails({ title, body, ...rest }: Props) {
         }),
       }),
       create("div", {
-        style: { marginLeft: "16px" },
+        style: firstBodyIndentation,
         children: createRowsRoot({ schema: firstBody }),
       }),
     ],

--- a/packages/docusaurus-plugin-openapi/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createStatusCodes.ts
@@ -33,11 +33,9 @@ export function createStatusCodes({ responses }: Props) {
             value: code,
             children: [
               create("div", {
-                style: { marginLeft: "16px" },
                 children: createDescription(responses[code].description),
               }),
               create("div", {
-                style: { marginLeft: "16px" },
                 children: createSchemaDetails({
                   title: "Schema",
                   body: {

--- a/packages/docusaurus-theme-openapi/src/theme/ApiItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiItem/styles.module.css
@@ -27,6 +27,25 @@
   max-width: 600px;
 }
 
+details > summary::before,
+details summary::-webkit-details-marker {
+  display: none;
+}
+
+details > summary::marker {
+  font-size: 1.5rem;
+}
+
+details > summary {
+  list-style-type: "\002B" !important;
+  margin-left: 1rem !important;
+  padding-left: 0.5rem !important;
+}
+
+details[open] > summary {
+  list-style-type: "\2212" !important;
+}
+
 @media (min-width: 997px) {
   .docItemCol {
     max-width: 75% !important;

--- a/packages/docusaurus-theme-openapi/src/theme/Tabs/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/Tabs/index.js
@@ -141,7 +141,7 @@ function ResponseCodeTabs(props) {
   };
 
   const tabItemListContainerRef = useRef(null);
-  const showTabArrows = values.length > 5;
+  const showTabArrows = values.length >= 5;
 
   const handleRightClick = () => {
     tabItemListContainerRef.current.scrollLeft += 90;

--- a/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
@@ -9,13 +9,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 5.5rem;
   height: 2.5rem;
   margin-top: 0 !important;
   margin-right: 0.5rem;
   border: 1px solid var(--openapi-code-dim-dark);
   border-radius: var(--ifm-global-radius);
-  padding: 1rem;
   font-weight: var(--ifm-font-weight-normal);
   color: var(--openapi-code-dim-dark);
 }
@@ -38,10 +36,10 @@
 .responseTabsContainer {
   display: flex;
   align-items: center;
+  max-width: 430px;
 }
 
 .responseTabsListContainer {
-  max-width: 440px;
   padding: 0 0.25rem;
   overflow-y: hidden;
   overflow-x: scroll;


### PR DESCRIPTION
## Description

This PR consists of the following changes: 
- Updated `<summary>` marker styling with +- icons
- Updated Schema indentation
  - Adjusting `marginLeft` to utilize `rem` units 
  - Conditionally setting `marginLeft` if the `firstBody` contains any `items`
  - Removal of Schema `object[]` label 
- Updated Tabs to handle smaller desktop sizes
  - Remove set `width` and `padding` to allow tab content to fit naturally

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

### Desktop | 1440 x 900
https://user-images.githubusercontent.com/48506502/158272244-19b7faec-2647-4bc7-a0df-b8ab77a49a08.mov

### Mobile | iPhone XR 
https://user-images.githubusercontent.com/48506502/158272912-7c38d5eb-702b-4b60-868e-4aef93fbe6d0.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
