### PR TITLE
[UI Cleanup]: Responsiveness tweaks v2 | Tabs | Sidebar 

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiPage/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiPage/styles.module.css
@@ -89,7 +89,7 @@ html[data-theme="dark"] {
   display: none;
 }
 
-@media (min-width: 1195px) {
+@media (min-width: 997px) {
   .apiMainContainer {
     flex-grow: 1;
     max-width: calc(100% - var(--api-sidebar-width));

--- a/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/Tabs/styles.module.css
@@ -37,6 +37,8 @@
   display: flex;
   align-items: center;
   max-width: 390px;
+  padding-left: 1rem;
+  overflow: hidden;
 }
 
 .responseTabsListContainer {
@@ -101,7 +103,7 @@
   transform: rotate(90deg);
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 500px) {
   .responseTabsTopSection {
     flex-direction: column;
     align-items: flex-start;
@@ -110,5 +112,6 @@
   .responseTabsContainer {
     width: 100%;
     margin-top: var(--ifm-spacing-vertical);
+    padding: 0;
   }
 }


### PR DESCRIPTION
## Description

- Revert to original API sidebar media query to remain consistent with mobile breakpoint (996px) throughout the site
- Optimize Tabs styling for better responsiveness
  - Change in flex-direction to column for screen sizes up to 500px
  - Added padding-left to container to create space between 'Response' title when the user sizes down the screen

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

### Before: 
https://user-images.githubusercontent.com/48506502/159074558-fed364ab-0557-427d-8d1e-fcc95081bb5a.mov

### After: 
https://user-images.githubusercontent.com/48506502/159074913-d467ef74-a185-4a8c-98e7-0145cbc8589d.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
