### PR TITLE
Prepare release v17.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 17.0.4 (Mar 21, 2022)
+
+High level enhancements
+
+- Nohoist `postman-collection` and `postman-code-generators` to support package-level patching.
+- Add schema guidelines to improve readability.
+- Improve responsiveness.
+
+Other enhancements and bug fixes
+
+- Add patch-package to standalone packages ([#29](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/29))
+- Add guidelines to collapsible schemas ([#27](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/27))
+- Merge pull request #26 from PaloAltoNetworks/response-tweaks-v2
+- Update tabs css
+- Revert to original ApiPage media query
+- Responsiveness tweaks ([#25](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/25))
+- Manually bump to 17.0.3 ([#24](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/24))
+- Merge pull request #23 from PaloAltoNetworks/ui-cleanup
+- Increase cypress viewport size
+- Hide ApiItem doc pagination on mobile
+- Pass down previous and next props to ApiDemoPanel from ApiItem
+- Import DocPaginator into ApiDemoPanel
+- Adjust responseTabsContainer width
+- Adjust apiSidebarContainer media query
+
 ## 17.0.3 (Mar 16, 2022)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -16,7 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.17",
     "@mdx-js/react": "^1.6.21",
-    "@paloaltonetworks/docusaurus-preset-openapi": "17.0.3",
+    "@paloaltonetworks/docusaurus-preset-openapi": "^17.0.4",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "17.0.3",
+  "version": "17.0.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/create-docusaurus-openapi/package.json
+++ b/packages/create-docusaurus-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paloaltonetworks/create-docusaurus-openapi",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "description": "Create Docusaurus apps easily.",
   "repository": {
     "type": "git",

--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@paloaltonetworks/docusaurus-plugin-openapi",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-plugin-proxy/package.json
+++ b/packages/docusaurus-plugin-proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@paloaltonetworks/docusaurus-plugin-proxy",
   "description": "A dev server proxy for Docusaurus.",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/docusaurus-preset-openapi/package.json
+++ b/packages/docusaurus-preset-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@paloaltonetworks/docusaurus-preset-openapi",
   "description": "OpenAPI preset for Docusaurus.",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@docusaurus/preset-classic": "2.0.0-beta.17",
-    "@paloaltonetworks/docusaurus-plugin-openapi": "17.0.3",
-    "@paloaltonetworks/docusaurus-plugin-proxy": "^17.0.1",
-    "@paloaltonetworks/docusaurus-theme-openapi": "17.0.3"
+    "@paloaltonetworks/docusaurus-plugin-openapi": "^17.0.4",
+    "@paloaltonetworks/docusaurus-plugin-proxy": "^17.0.4",
+    "@paloaltonetworks/docusaurus-theme-openapi": "^17.0.4"
   },
   "peerDependencies": {
     "react": "^16.8.4 || ^17.0.0",

--- a/packages/docusaurus-template-openapi/package.json
+++ b/packages/docusaurus-template-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paloaltonetworks/docusaurus-template-openapi",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "keywords": [
     "react",
     "create-docusaurus",

--- a/packages/docusaurus-theme-openapi/package.json
+++ b/packages/docusaurus-theme-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@paloaltonetworks/docusaurus-theme-openapi",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -41,7 +41,7 @@
     "@docusaurus/theme-common": "2.0.0-beta.17",
     "@mdx-js/react": "^1.6.21",
     "@monaco-editor/react": "^4.3.1",
-    "@paloaltonetworks/docusaurus-plugin-openapi": "17.0.3",
+    "@paloaltonetworks/docusaurus-plugin-openapi": "^17.0.4",
     "@reduxjs/toolkit": "^1.7.1",
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",


### PR DESCRIPTION
## Description

High level enhancements

- Nohoist `postman-collection` and `postman-code-generators` to support package-level patching.
- Add schema guidelines to improve readability.
- Improve responsiveness.

Other enhancements and bug fixes

- Add patch-package to standalone packages ([#29](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/29))
- Add guidelines to collapsible schemas ([#27](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/27))
- Merge pull request #26 from PaloAltoNetworks/response-tweaks-v2
- Update tabs css
- Revert to original ApiPage media query
- Responsiveness tweaks ([#25](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/25))
- Manually bump to 17.0.3 ([#24](https://github.com/PaloAltoNetworks/docusaurus-openapi/pull/24))
- Merge pull request #23 from PaloAltoNetworks/ui-cleanup
- Increase cypress viewport size
- Hide ApiItem doc pagination on mobile
- Pass down previous and next props to ApiDemoPanel from ApiItem
- Import DocPaginator into ApiDemoPanel
- Adjust responseTabsContainer width
- Adjust apiSidebarContainer media query

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
