### PR TITLE
[Optimization]: POC - Create new Theme Components

### DIFF
--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -43,7 +43,6 @@
     "js-yaml": "^4.1.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.17.20",
-    "react-markdown": "^8.0.1",
     "remark-admonitions": "^1.2.1",
     "webpack": "^5.61.0"
   },

--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -43,6 +43,7 @@
     "js-yaml": "^4.1.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.17.20",
+    "react-markdown": "^8.0.1",
     "remark-admonitions": "^1.2.1",
     "webpack": "^5.61.0"
   },

--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
@@ -5,14 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { escape } from "lodash";
-
 import { ApiItem } from "../types";
-import { createDescription } from "./createDescription";
 import { createDetails } from "./createDetails";
 import { createDetailsSummary } from "./createDetailsSummary";
-import { getQualifierMessage, getSchemaName } from "./schema";
-import { create, guard } from "./utils";
+import { create } from "./utils";
 
 interface Props {
   parameters: ApiItem["parameters"];
@@ -27,7 +23,7 @@ export function createParamsDetails({ parameters, type }: Props) {
   if (params.length === 0) {
     return undefined;
   }
-  // Create new component to render params details
+
   return createDetails({
     children: [
       createDetailsSummary({
@@ -40,7 +36,6 @@ export function createParamsDetails({ parameters, type }: Props) {
         ],
       }),
       create("div", {
-        // ParamsContainer -> Creates an unordered list
         children: [
           create("ul", {
             children: params.map((param) =>

--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
@@ -27,7 +27,7 @@ export function createParamsDetails({ parameters, type }: Props) {
   if (params.length === 0) {
     return undefined;
   }
-
+  // Create new component to render params details
   return createDetails({
     children: [
       createDetailsSummary({
@@ -40,65 +40,13 @@ export function createParamsDetails({ parameters, type }: Props) {
         ],
       }),
       create("div", {
+        // ParamsContainer -> Creates an unordered list
         children: [
           create("ul", {
             children: params.map((param) =>
-              create("li", {
+              create("ParamsItem", {
                 className: "paramsItem",
-                style: {
-                  marginLeft: "1rem",
-                  position: "relative",
-                  paddingLeft: "1rem",
-                  marginTop: 0,
-                  marginBottom: 0,
-                  borderLeft: "thin solid var(--ifm-color-gray-500)",
-                },
-                children: [
-                  create("strong", { children: param.name }),
-                  guard(param.schema, (schema) =>
-                    create("span", {
-                      style: { opacity: "0.6" },
-                      children: ` ${getSchemaName(schema)}`,
-                    })
-                  ),
-                  guard(param.required, () => [
-                    create("strong", {
-                      style: {
-                        fontSize: "var(--ifm-code-font-size)",
-                        color: "var(--openapi-required)",
-                      },
-                      children: " required",
-                    }),
-                  ]),
-                  guard(getQualifierMessage(param.schema), (message) =>
-                    create("div", {
-                      //   style: { marginTop: "var(--ifm-table-cell-padding)" },
-                      children: createDescription(message),
-                    })
-                  ),
-                  guard(param.description, (description) =>
-                    create("div", {
-                      //   style: { marginTop: "var(--ifm-table-cell-padding)" },
-                      children: createDescription(description),
-                    })
-                  ),
-                  guard(param.example, (example) =>
-                    create("div", {
-                      //   style: { marginTop: "var(--ifm-table-cell-padding)" },
-                      children: escape(`Example: ${example}`),
-                    })
-                  ),
-                  guard(param.examples, (examples) =>
-                    create("div", {
-                      //   style: { marginTop: "var(--ifm-table-cell-padding)" },
-                      children: Object.entries(examples).map(([k, v]) =>
-                        create("div", {
-                          children: escape(`Example (${k}): ${v.value}`),
-                        })
-                      ),
-                    })
-                  ),
-                ],
+                param: param,
               })
             ),
           }),

--- a/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createParamsDetails.ts
@@ -25,6 +25,7 @@ export function createParamsDetails({ parameters, type }: Props) {
   }
 
   return createDetails({
+    style: { marginBottom: "1rem" },
     children: [
       createDetailsSummary({
         children: [

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -67,16 +67,17 @@ function createRow({ name, schema, required }: RowProps) {
               ],
             }),
             create("div", {
+              style: { marginLeft: "1rem" },
               children: [
                 guard(getQualifierMessage(schema), (message) =>
                   create("div", {
-                    style: { marginLeft: "1rem" },
+                    style: { marginTop: ".5rem", marginBottom: ".5rem" },
                     children: createDescription(message),
                   })
                 ),
                 guard(schema.description, (description) =>
                   create("div", {
-                    style: { marginLeft: "1rem" },
+                    style: { marginTop: ".5rem", marginBottom: ".5rem" },
                     children: createDescription(description),
                   })
                 ),
@@ -106,39 +107,31 @@ interface RowsProps {
 function createRows({ schema }: RowsProps): string | undefined {
   // object
   if (schema.properties !== undefined) {
-    return create("li", {
-      style: { marginLeft: "1rem" },
-      children: create("ul", {
-        children: Object.entries(schema.properties).map(([key, val]) =>
-          createRow({
-            name: key,
-            schema: val,
-            required: Array.isArray(schema.required)
-              ? schema.required.includes(key)
-              : false,
-          })
-        ),
-      }),
+    return create("ul", {
+      children: Object.entries(schema.properties).map(([key, val]) =>
+        createRow({
+          name: key,
+          schema: val,
+          required: Array.isArray(schema.required)
+            ? schema.required.includes(key)
+            : false,
+        })
+      ),
     });
   }
 
   // TODO: This can be a bit complicated types can be missmatched and there can be nested allOfs which need to be resolved before merging properties
   if (schema.allOf !== undefined) {
     const { properties, required } = resolveAllOf(schema.allOf);
-    return create("li", {
+    return create("ul", {
       className: "allOf",
-      style: {
-        marginLeft: "1rem",
-      },
-      children: create("ul", {
-        children: Object.entries(properties).map(([key, val]) =>
-          createRow({
-            name: key,
-            schema: val,
-            required: Array.isArray(required) ? required.includes(key) : false,
-          })
-        ),
-      }),
+      children: Object.entries(properties).map(([key, val]) =>
+        createRow({
+          name: key,
+          schema: val,
+          required: Array.isArray(required) ? required.includes(key) : false,
+        })
+      ),
     });
   }
 
@@ -250,10 +243,6 @@ export function createSchemaDetails({ title, body, ...rest }: Props) {
     }
   }
 
-  const firstBodyIndentation = firstBody.items
-    ? { marginLeft: "0" }
-    : { marginLeft: "1rem" };
-
   return createDetails({
     ...rest,
     children: [
@@ -273,23 +262,18 @@ export function createSchemaDetails({ title, body, ...rest }: Props) {
         ],
       }),
       create("div", {
-        style: { marginLeft: "1rem" },
-        children: create("div", {
-          children: create("div", {
-            style: { textAlign: "left" },
-            children: [
-              guard(body.description, () => [
-                create("div", {
-                  style: { marginTop: "1rem", marginBottom: "1rem" },
-                  children: createDescription(body.description),
-                }),
-              ]),
-            ],
-          }),
-        }),
+        style: { textAlign: "left", marginLeft: "1rem" },
+        children: [
+          guard(body.description, () => [
+            create("div", {
+              style: { marginTop: "1rem", marginBottom: "1rem" },
+              children: createDescription(body.description),
+            }),
+          ]),
+        ],
       }),
       create("ul", {
-        style: firstBodyIndentation,
+        style: { marginLeft: "1rem" },
         children: createRowsRoot({ schema: firstBody }),
       }),
     ],

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -42,7 +42,8 @@ interface RowProps {
 function createRow({ name, schema, required }: RowProps) {
   const schemaName = getSchemaName(schema, true);
   if (schemaName && (schemaName === "object" || schemaName === "object[]")) {
-    return create("li", {
+    return create("SchemaItem", {
+      collapsible: true,
       className: "schemaItem",
       children: [
         createDetails({
@@ -87,7 +88,9 @@ function createRow({ name, schema, required }: RowProps) {
       ],
     });
   }
+
   return create("SchemaItem", {
+    collapsible: false,
     name,
     required,
     schemaDescription: schema.description,

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -12,17 +12,6 @@ import { createDetailsSummary } from "./createDetailsSummary";
 import { getQualifierMessage, getSchemaName } from "./schema";
 import { create, guard } from "./utils";
 
-const listStyle = {
-  listStyle: "none",
-  position: "relative",
-  paddingBottom: "5px",
-  paddingTop: "5px",
-  paddingLeft: "1rem",
-  marginTop: 0,
-  marginBottom: 0,
-  borderLeft: "thin solid var(--ifm-color-gray-500)",
-};
-
 function resolveAllOf(allOf: SchemaObject[]) {
   // TODO: naive implementation (only supports objects, no directly nested allOf)
   const properties = allOf.reduce((acc, cur) => {

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -41,13 +41,53 @@ interface RowProps {
 
 function createRow({ name, schema, required }: RowProps) {
   const schemaName = getSchemaName(schema, true);
+  if (schemaName && (schemaName === "object" || schemaName === "object[]")) {
+    return create("li", {
+      className: "schemaItem",
+      children: [
+        createDetails({
+          children: [
+            createDetailsSummary({
+              children: [
+                create("strong", { children: name }),
+                create("span", {
+                  style: { opacity: "0.6" },
+                  children: ` ${getSchemaName(schema, true)}`,
+                }),
+                guard(required, () => [
+                  create("strong", {
+                    style: {
+                      fontSize: "var(--ifm-code-font-size)",
+                      color: "var(--openapi-required)",
+                    },
+                    children: " required",
+                  }),
+                ]),
+              ],
+            }),
+            create("div", {
+              children: [
+                guard(getQualifierMessage(schema), (message) =>
+                  create("div", {
+                    style: { marginLeft: "1rem" },
+                    children: createDescription(message),
+                  })
+                ),
+                guard(schema.description, (description) =>
+                  create("div", {
+                    style: { marginLeft: "1rem" },
+                    children: createDescription(description),
+                  })
+                ),
+                createRows({ schema: schema }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+  }
   return create("SchemaItem", {
-    // childrenRows: createRows({ schema: schema }),
-    // style: listStyle,
-    collapsible:
-      schemaName && (schemaName === "object" || schemaName === "object[]")
-        ? true
-        : false,
     name,
     required,
     schemaDescription: schema.description,

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -52,85 +52,18 @@ interface RowProps {
 
 function createRow({ name, schema, required }: RowProps) {
   const schemaName = getSchemaName(schema, true);
-  if (schemaName && (schemaName === "object" || schemaName === "object[]")) {
-    return create("li", {
-      className: "schemaItem",
-      style: listStyle,
-      children: [
-        createDetails({
-          children: [
-            createDetailsSummary({
-              children: [
-                create("strong", { children: name }),
-                create("span", {
-                  style: { opacity: "0.6" },
-                  children: ` ${getSchemaName(schema, true)}`,
-                }),
-                guard(required, () => [
-                  create("strong", {
-                    style: {
-                      fontSize: "var(--ifm-code-font-size)",
-                      color: "var(--openapi-required)",
-                    },
-                    children: " required",
-                  }),
-                ]),
-              ],
-            }),
-            create("div", {
-              children: [
-                guard(getQualifierMessage(schema), (message) =>
-                  create("div", {
-                    style: { marginLeft: "1rem" },
-                    children: createDescription(message),
-                  })
-                ),
-                guard(schema.description, (description) =>
-                  create("div", {
-                    style: { marginLeft: "1rem" },
-                    children: createDescription(description),
-                  })
-                ),
-                createRows({ schema: schema }),
-              ],
-            }),
-          ],
-        }),
-      ],
-    });
-  }
-  return create("li", {
-    className: "schemaItem",
-    style: listStyle,
-    children: create("div", {
-      children: [
-        create("strong", { children: name }),
-        create("span", {
-          style: { opacity: "0.6" },
-          children: ` ${getSchemaName(schema, true)}`,
-        }),
-        guard(required, () => [
-          create("strong", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              color: "var(--openapi-required)",
-            },
-            children: " required",
-          }),
-        ]),
-        guard(getQualifierMessage(schema), (message) =>
-          create("div", {
-            children: createDescription(message),
-          })
-        ),
-        guard(schema.description, (description) =>
-          create("div", {
-            children: createDescription(description),
-          })
-        ),
-        createRows({ schema: schema }),
-      ],
-    }),
+  return create("SchemaItem", {
+    // childrenRows: createRows({ schema: schema }),
+    // style: listStyle,
+    collapsible:
+      schemaName && (schemaName === "object" || schemaName === "object[]")
+        ? true
+        : false,
+    name,
+    required,
+    schemaDescription: schema.description,
+    schemaName: getSchemaName(schema, true),
+    qualifierMessage: getQualifierMessage(schema),
   });
 }
 

--- a/packages/docusaurus-plugin-openapi/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/index.ts
@@ -30,6 +30,7 @@ export function createApiPageMD({
   return render([
     `import Tabs from "@theme/Tabs";\n\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
+    `import ParamsItem from "@theme/ParamsItem";\n\n`,
     `## ${escape(title)}\n\n`,
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(escape(description)),

--- a/packages/docusaurus-plugin-openapi/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/index.ts
@@ -28,10 +28,10 @@ export function createApiPageMD({
   },
 }: ApiPageMetadata) {
   return render([
-    `import Tabs from "@theme/Tabs";\n\n`,
+    `import ParamsItem from "@theme/ParamsItem";\n`,
+    `import SchemaItem from "@theme/SchemaItem"\n`,
+    `import Tabs from "@theme/Tabs";\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
-    `import ParamsItem from "@theme/ParamsItem";\n\n`,
-    `import SchemaItem from "@theme/SchemaItem"\n\n`,
     `## ${escape(title)}\n\n`,
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(escape(description)),

--- a/packages/docusaurus-plugin-openapi/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/index.ts
@@ -31,6 +31,7 @@ export function createApiPageMD({
     `import Tabs from "@theme/Tabs";\n\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
     `import ParamsItem from "@theme/ParamsItem";\n\n`,
+    `import SchemaItem from "@theme/SchemaItem"\n\n`,
     `## ${escape(title)}\n\n`,
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(escape(description)),

--- a/packages/docusaurus-theme-openapi/package.json
+++ b/packages/docusaurus-theme-openapi/package.json
@@ -52,6 +52,7 @@
     "prism-react-renderer": "^1.2.1",
     "process": "^0.11.10",
     "react-magic-dropzone": "^1.0.1",
+    "react-markdown": "^8.0.1",
     "react-redux": "^7.2.0",
     "redux-devtools-extension": "^2.13.8",
     "webpack": "^5.61.0"

--- a/packages/docusaurus-theme-openapi/src/theme/ApiItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiItem/styles.module.css
@@ -71,6 +71,14 @@
   font-size: 14px;
 }
 
+:global(.schemaItem) {
+  list-style: none;
+  position: relative;
+  margin: 0 !important;
+  padding: 5px 0 5px 1rem;
+  border-left: thin solid var(--ifm-color-gray-500) !important;
+}
+
 :global(.schemaItem:hover) {
   background-color: var(--ifm-menu-color-background-active);
 }

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -6,6 +6,7 @@
  * ========================================================================== */
 
 import React from "react";
+import ReactMarkdown from "react-markdown";
 
 import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
 import {
@@ -29,7 +30,9 @@ function ParamsItem({
 
   // TODO: getQualiferMessage() contains output in MD format, need to be able to handle formatting here?
   const renderSchema = guard(getQualifierMessage(schema), (message) => (
-    <div>{createDescription(message)}</div>
+    <div>
+      <ReactMarkdown children={createDescription(message)} />
+    </div>
   ));
 
   const renderDescription = guard(description, (description) => (

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -21,11 +21,11 @@ function ParamsItem({
   param: { description, example, examples, name, required, schema },
 }) {
   const renderSchemaName = guard(schema, (schema) => (
-    <span> {getSchemaName(schema)}</span>
+    <span className={styles.schemaName}> {getSchemaName(schema)}</span>
   ));
 
   const renderSchemaRequired = guard(required, () => (
-    <strong> required</strong>
+    <strong className={styles.paramsRequired}> required</strong>
   ));
 
   const renderSchema = guard(getQualifierMessage(schema), (message) => (
@@ -37,7 +37,7 @@ function ParamsItem({
   ));
 
   const renderExample = guard(example, (example) => (
-    <div>{escape(`Example: ${example}`)}</div>
+    <div>{`Example: ${example}`}</div>
   ));
 
   const renderExamples = guard(examples, (examples) => {
@@ -45,7 +45,7 @@ function ParamsItem({
     return (
       <>
         {exampleEntries.map(([k, v]) => (
-          <div>{escape(`Example (${k}): ${v.value}`)}</div>
+          <div>{`Example (${k}): ${v.value}`}</div>
         ))}
       </>
     );

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -1,12 +1,20 @@
-import React from "react";
-import escape from "lodash/escape";
-import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
-import { guard } from "../../../../docusaurus-plugin-openapi/src/markdown/utils";
-import {
-  getQualifierMessage,
-  getSchemaName,
-} from "../../../../docusaurus-plugin-openapi/src/markdown/schema";
+/* ============================================================================
+ * Copyright (c) Cloud Annotations
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
 
+import React from "react";
+
+import escape from "lodash/escape";
+
+import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
+import {
+  getSchemaName,
+  getQualifierMessage,
+} from "../../../../docusaurus-plugin-openapi/src/markdown/schema";
+import { guard } from "../../../../docusaurus-plugin-openapi/src/markdown/utils";
 import styles from "./styles.module.css";
 
 function ParamsItem({

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -7,8 +7,6 @@
 
 import React from "react";
 
-import escape from "lodash/escape";
-
 import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
 import {
   getSchemaName,
@@ -28,6 +26,7 @@ function ParamsItem({
     <strong className={styles.paramsRequired}> required</strong>
   ));
 
+  // TODO: getQualiferMessage() contains output in MD format, need to be able to handle formatting here?
   const renderSchema = guard(getQualifierMessage(schema), (message) => (
     <div>{createDescription(message)}</div>
   ));

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -13,6 +13,7 @@ import {
   getQualifierMessage,
 } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/schema";
 import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
+
 import styles from "./styles.module.css";
 
 function ParamsItem({

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -6,7 +6,6 @@
  * ========================================================================== */
 
 import React from "react";
-import ReactMarkdown from "react-markdown";
 
 import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
 import {
@@ -14,6 +13,7 @@ import {
   getQualifierMessage,
 } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/schema";
 import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
+import ReactMarkdown from "react-markdown";
 
 import styles from "./styles.module.css";
 

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -7,12 +7,12 @@
 
 import React from "react";
 
-import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
+import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
 import {
   getSchemaName,
   getQualifierMessage,
-} from "../../../../docusaurus-plugin-openapi/src/markdown/schema";
-import { guard } from "../../../../docusaurus-plugin-openapi/src/markdown/utils";
+} from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/schema";
+import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
 import styles from "./styles.module.css";
 
 function ParamsItem({

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -9,8 +9,8 @@ import React from "react";
 
 import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
 import {
-  getSchemaName,
   getQualifierMessage,
+  getSchemaName,
 } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/schema";
 import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
 import ReactMarkdown from "react-markdown";
@@ -36,7 +36,9 @@ function ParamsItem({
   ));
 
   const renderDescription = guard(description, (description) => (
-    <div>{createDescription(description)}</div>
+    <div>
+      <ReactMarkdown children={createDescription(description)} />
+    </div>
   ));
 
   const renderExample = guard(example, (example) => (

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -1,0 +1,59 @@
+import React from "react";
+import escape from "lodash/escape";
+import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
+import { guard } from "../../../../docusaurus-plugin-openapi/src/markdown/utils";
+import {
+  getQualifierMessage,
+  getSchemaName,
+} from "../../../../docusaurus-plugin-openapi/src/markdown/schema";
+
+import styles from "./styles.module.css";
+
+function ParamsItem({
+  param: { description, example, examples, name, required, schema },
+}) {
+  const renderSchemaName = guard(schema, (schema) => (
+    <span> {getSchemaName(schema)}</span>
+  ));
+
+  const renderSchemaRequired = guard(required, () => (
+    <strong> required</strong>
+  ));
+
+  const renderSchema = guard(getQualifierMessage(schema), (message) => (
+    <div>{createDescription(message)}</div>
+  ));
+
+  const renderDescription = guard(description, (description) => (
+    <div>{createDescription(description)}</div>
+  ));
+
+  const renderExample = guard(example, (example) => (
+    <div>{escape(`Example: ${example}`)}</div>
+  ));
+
+  const renderExamples = guard(examples, (examples) => {
+    const exampleEntries = Object.entries(examples);
+    return (
+      <>
+        {exampleEntries.map(([k, v]) => (
+          <div>{escape(`Example (${k}): ${v.value}`)}</div>
+        ))}
+      </>
+    );
+  });
+
+  return (
+    <li className={styles.paramsItem}>
+      <strong>{name}</strong>
+      {renderSchemaName}
+      {renderSchemaRequired}
+      {renderSchema}
+      {renderDescription}
+      {renderExample}
+      {renderExamples}
+    </li>
+  );
+}
+
+export default ParamsItem;

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/styles.module.css
@@ -3,6 +3,7 @@
   position: relative;
   padding-left: 1rem;
   border-left: thin solid var(--ifm-color-gray-500) !important;
+  margin-top: unset !important;
 }
 
 .paramsItem:hover {

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/styles.module.css
@@ -12,3 +12,12 @@
 .paramsItem:focus {
   background-color: var(--ifm-menu-color-background-active);
 }
+
+.schemaName {
+  opacity: 0.6;
+}
+
+.paramsRequired {
+  font-size: var(--ifm-code-font-size);
+  color: var(--openapi-required);
+}

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/styles.module.css
@@ -1,0 +1,14 @@
+.paramsItem {
+  margin: 0 0 0 1rem !important;
+  position: relative;
+  padding-left: 1rem;
+  border-left: thin solid var(--ifm-color-gray-500) !important;
+}
+
+.paramsItem:hover {
+  background-color: var(--ifm-menu-color-background-active);
+}
+
+.paramsItem:focus {
+  background-color: var(--ifm-menu-color-background-active);
+}

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -6,7 +6,7 @@
  * ========================================================================== */
 
 import React from "react";
-
+import ReactMarkdown from "react-markdown";
 import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
 import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
 
@@ -31,7 +31,7 @@ function SchemaItem({
 
   const renderQualifierMessage = guard(qualifierMessage, (message) => (
     <div className={styles.schemaQualifierMessage}>
-      {createDescription(message)}
+      <ReactMarkdown children={createDescription(message)} />
     </div>
   ));
 

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -7,8 +7,8 @@
 
 import React from "react";
 
-import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
-import { guard } from "../../../../docusaurus-plugin-openapi/src/markdown/utils";
+import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
+import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
 import styles from "./styles.module.css";
 
 function SchemaItem({

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -12,8 +12,6 @@ import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/
 import styles from "./styles.module.css";
 
 function SchemaItem({
-  childrenRows,
-  collapsible,
   name,
   qualifierMessage,
   required,
@@ -36,35 +34,15 @@ function SchemaItem({
     </div>
   ));
 
-  const schemaContent = (
-    <div>
-      <strong>{name}</strong>
-      <span className={styles.schemaName}> {schemaName}</span>
-      {renderRequired}
-      {renderQualifierMessage}
-      {renderSchemaDescription}
-      {/* {childrenRows} */}
-    </div>
-  );
-
-  const collapsibleSchemaContent = (
-    <details>
-      <summary>
+  return (
+    <li className={styles.schemaItem}>
+      <div>
         <strong>{name}</strong>
         <span className={styles.schemaName}> {schemaName}</span>
         {renderRequired}
-      </summary>
-      <div>
         {renderQualifierMessage}
         {renderSchemaDescription}
-        {/* {childrenRows} */}
       </div>
-    </details>
-  );
-
-  return (
-    <li className={styles.schemaItem}>
-      {collapsible ? collapsibleSchemaContent : schemaContent}
     </li>
   );
 }

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -9,7 +9,6 @@ import React from "react";
 
 import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
 import { guard } from "../../../../docusaurus-plugin-openapi/src/markdown/utils";
-
 import styles from "./styles.module.css";
 
 function SchemaItem({

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -6,9 +6,10 @@
  * ========================================================================== */
 
 import React from "react";
-import ReactMarkdown from "react-markdown";
+
 import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
 import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
+import ReactMarkdown from "react-markdown";
 
 import styles from "./styles.module.css";
 

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -28,7 +28,7 @@ function SchemaItem({
 
   const renderSchemaDescription = guard(schemaDescription, (description) => (
     <div className={styles.schemaDescription}>
-      {createDescription(description)}
+      <ReactMarkdown children={createDescription(description)} />
     </div>
   ));
 

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -9,6 +9,7 @@ import React from "react";
 
 import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
 import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
+
 import styles from "./styles.module.css";
 
 function SchemaItem({

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -1,0 +1,73 @@
+/* ============================================================================
+ * Copyright (c) Cloud Annotations
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React from "react";
+
+import { createDescription } from "../../../../docusaurus-plugin-openapi/src/markdown/createDescription";
+import { guard } from "../../../../docusaurus-plugin-openapi/src/markdown/utils";
+
+import styles from "./styles.module.css";
+
+function SchemaItem({
+  childrenRows,
+  collapsible,
+  name,
+  qualifierMessage,
+  required,
+  schemaDescription,
+  schemaName,
+}) {
+  const renderRequired = guard(required, () => (
+    <strong className={styles.required}> required</strong>
+  ));
+
+  const renderSchemaDescription = guard(schemaDescription, (description) => (
+    <div className={styles.schemaDescription}>
+      {createDescription(description)}
+    </div>
+  ));
+
+  const renderQualifierMessage = guard(qualifierMessage, (message) => (
+    <div className={styles.schemaQualifierMessage}>
+      {createDescription(message)}
+    </div>
+  ));
+
+  const schemaContent = (
+    <div>
+      <strong>{name}</strong>
+      <span className={styles.schemaName}> {schemaName}</span>
+      {renderRequired}
+      {renderQualifierMessage}
+      {renderSchemaDescription}
+      {/* {childrenRows} */}
+    </div>
+  );
+
+  const collapsibleSchemaContent = (
+    <details>
+      <summary>
+        <strong>{name}</strong>
+        <span className={styles.schemaName}> {schemaName}</span>
+        {renderRequired}
+      </summary>
+      <div>
+        {renderQualifierMessage}
+        {renderSchemaDescription}
+        {/* {childrenRows} */}
+      </div>
+    </details>
+  );
+
+  return (
+    <li className={styles.schemaItem}>
+      {collapsible ? collapsibleSchemaContent : schemaContent}
+    </li>
+  );
+}
+
+export default SchemaItem;

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -14,6 +14,8 @@ import ReactMarkdown from "react-markdown";
 import styles from "./styles.module.css";
 
 function SchemaItem({
+  children: collapsibleSchemaContent,
+  collapsible,
   name,
   qualifierMessage,
   required,
@@ -36,15 +38,19 @@ function SchemaItem({
     </div>
   ));
 
+  const schemaContent = (
+    <div>
+      <strong>{name}</strong>
+      <span className={styles.schemaName}> {schemaName}</span>
+      {renderRequired}
+      {renderQualifierMessage}
+      {renderSchemaDescription}
+    </div>
+  );
+
   return (
     <li className={styles.schemaItem}>
-      <div>
-        <strong>{name}</strong>
-        <span className={styles.schemaName}> {schemaName}</span>
-        {renderRequired}
-        {renderQualifierMessage}
-        {renderSchemaDescription}
-      </div>
+      {collapsible ? collapsibleSchemaContent : schemaContent}
     </li>
   );
 }

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/styles.module.css
@@ -18,11 +18,6 @@
   opacity: 0.6;
 }
 
-.schemaDescription,
-.schemaQualiferMessage {
-  margin-left: 1rem;
-}
-
 .required {
   font-size: var(--ifm-code-font-size);
   color: var(--openapi-required);

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/styles.module.css
@@ -1,0 +1,29 @@
+.schemaItem {
+  list-style: none;
+  position: relative;
+  margin: 0 !important;
+  padding: 5px 0 5px 1rem;
+  border-left: thin solid var(--ifm-color-gray-500) !important;
+}
+
+.schemaItem:hover {
+  background-color: var(--ifm-menu-color-background-active);
+}
+
+.schemaItem:focus {
+  background-color: var(--ifm-menu-color-background-active);
+}
+
+.schemaName {
+  opacity: 0.6;
+}
+
+.schemaDescription,
+.schemaQualiferMessage {
+  margin-left: 1rem;
+}
+
+.required {
+  font-size: var(--ifm-code-font-size);
+  color: var(--openapi-required);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,6 +3299,13 @@
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
   integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
 
+"@types/debug@^4.0.0":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
@@ -3447,6 +3454,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/mdurl@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
+  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
+
 "@types/mdx-js__react@^1.5.4":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@types/mdx-js__react/-/mdx-js__react-1.5.5.tgz#fa6daa1a28336d77b6cf071aacc7e497600de9ee"
@@ -3468,6 +3480,11 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*", "@types/node@^17.0.2", "@types/node@^17.0.5":
   version "17.0.23"
@@ -3513,7 +3530,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.0.0":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
@@ -4569,6 +4586,11 @@ bail@^1.0.0:
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -4919,6 +4941,11 @@ character-entities@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
   integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
 
+character-entities@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.1.tgz#98724833e1e27990dee0bd0f2b8a859c3476aac7"
+  integrity sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ==
+
 character-reference-invalid@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
@@ -5238,6 +5265,11 @@ comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz#d4c25abb679b7751c880be623c1179780fe1dd98"
+  integrity sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==
 
 commander@2.20.3, commander@^2.20.0:
   version "2.20.3"
@@ -5913,7 +5945,7 @@ debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -5956,6 +5988,13 @@ decimal.js@^10.2.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
+
+decode-named-character-reference@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.1.tgz#57b2bd9112659cacbc449d3577d7dadb8e1f3d1b"
+  integrity sha512-YV/0HQHreRwKb7uBopyIkLG17jG6Sv2qUchk9qSoVJ2f+flwRsPNBO0hAnjt6mTNYUT+vw9Gy2ihXg4sUWPi2w==
+  dependencies:
+    character-entities "^2.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -6066,6 +6105,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -6131,6 +6175,11 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -7729,6 +7778,11 @@ hast-util-to-parse5@^6.0.0:
     xtend "^4.0.0"
     zwitch "^1.0.0"
 
+hast-util-whitespace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz#4fc1086467cc1ef5ba20673cb6b03cec3a970f1c"
+  integrity sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg==
+
 hastscript@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-5.1.2.tgz#bde2c2e56d04c62dd24e8c5df288d050a355fb8a"
@@ -8401,6 +8455,11 @@ is-plain-obj@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
+
+is-plain-obj@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.0.0.tgz#06c0999fd7574edf5a906ba5644ad0feb3a84d22"
+  integrity sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==
 
 is-plain-object@^2.0.4:
   version "2.0.4"
@@ -9206,6 +9265,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kleur@^4.0.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.4.tgz#8c202987d7e577766d039a8cd461934c01cda04d"
+  integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
+
 klona@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
@@ -9702,6 +9766,33 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-definitions@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-5.1.0.tgz#b6d10ef00a3c4cf191e8d9a5fa58d7f4a366f817"
+  integrity sha512-5hcR7FL2EuZ4q6lLMUK5w4lHT2H3vqL9quPvYZ/Ku5iifrirfMHiGdhxdXMUbUkDmz5I+TYMd7nbaxUhbQkfpQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    unist-util-visit "^3.0.0"
+
+mdast-util-from-markdown@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz#84df2924ccc6c995dec1e2368b2b208ad0a76268"
+  integrity sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
+
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz#0cfc82089494c52d46eb0e3edb7a4eb2aea021eb"
@@ -9716,10 +9807,31 @@ mdast-util-to-hast@10.0.1:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
+mdast-util-to-hast@^12.1.0:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.1.1.tgz#89a2bb405eaf3b05eb8bf45157678f35eef5dbca"
+  integrity sha512-qE09zD6ylVP14jV4mjLIhDBOrpFdShHZcEsYvvKGABlr9mGbV7mTlRWdoFxL/EYSTNDiC9GZXy7y8Shgb9Dtzw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    "@types/mdurl" "^1.0.0"
+    mdast-util-definitions "^5.0.0"
+    mdurl "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    unist-builder "^3.0.0"
+    unist-util-generated "^2.0.0"
+    unist-util-position "^4.0.0"
+    unist-util-visit "^4.0.0"
+
 mdast-util-to-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
   integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
+
+mdast-util-to-string@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz#56c506d065fbf769515235e577b5a261552d56e9"
+  integrity sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -9784,6 +9896,201 @@ methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromark-core-commonmark@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz#edff4c72e5993d93724a3c206970f5a15b0585ad"
+  integrity sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-factory-destination "^1.0.0"
+    micromark-factory-label "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-factory-title "^1.0.0"
+    micromark-factory-whitespace "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-classify-character "^1.0.0"
+    micromark-util-html-tag-name "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
+
+micromark-factory-destination@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz#fef1cb59ad4997c496f887b6977aa3034a5a277e"
+  integrity sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-label@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz#6be2551fa8d13542fcbbac478258fb7a20047137"
+  integrity sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-space@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz#cebff49968f2b9616c0fcb239e96685cb9497633"
+  integrity sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-title@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz#7e09287c3748ff1693930f176e1c4a328382494f"
+  integrity sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-whitespace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz#e991e043ad376c1ba52f4e49858ce0794678621c"
+  integrity sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-character@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-1.1.0.tgz#d97c54d5742a0d9611a68ca0cd4124331f264d86"
+  integrity sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-chunked@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz#5b40d83f3d53b84c4c6bce30ed4257e9a4c79d06"
+  integrity sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-classify-character@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz#cbd7b447cb79ee6997dd274a46fc4eb806460a20"
+  integrity sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-combine-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz#91418e1e74fb893e3628b8d496085639124ff3d5"
+  integrity sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-decode-numeric-character-reference@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz#dcc85f13b5bd93ff8d2868c3dba28039d490b946"
+  integrity sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-decode-string@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz#942252ab7a76dec2dbf089cc32505ee2bc3acf02"
+  integrity sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-encode@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz#2c1c22d3800870ad770ece5686ebca5920353383"
+  integrity sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==
+
+micromark-util-html-tag-name@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.0.0.tgz#75737e92fef50af0c6212bd309bc5cb8dbd489ed"
+  integrity sha512-NenEKIshW2ZI/ERv9HtFNsrn3llSPZtY337LID/24WeLqMzeZhBEE6BQ0vS2ZBjshm5n40chKtJ3qjAbVV8S0g==
+
+micromark-util-normalize-identifier@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz#4a3539cb8db954bbec5203952bfe8cedadae7828"
+  integrity sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-resolve-all@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz#a7c363f49a0162e931960c44f3127ab58f031d88"
+  integrity sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==
+  dependencies:
+    micromark-util-types "^1.0.0"
+
+micromark-util-sanitize-uri@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz#27dc875397cd15102274c6c6da5585d34d4f12b2"
+  integrity sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-subtokenize@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz#ff6f1af6ac836f8bfdbf9b02f40431760ad89105"
+  integrity sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-util-symbol@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz#b90344db62042ce454f351cf0bebcc0a6da4920e"
+  integrity sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==
+
+micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-1.0.2.tgz#f4220fdb319205812f99c40f8c87a9be83eded20"
+  integrity sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==
+
+micromark@^3.0.0:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.0.10.tgz#1eac156f0399d42736458a14b0ca2d86190b457c"
+  integrity sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    micromark-core-commonmark "^1.0.1"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
 
 micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.5"
@@ -10011,6 +10318,11 @@ monaco-editor@^0.31.1:
   version "0.31.1"
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.31.1.tgz#67f597b3e45679d1f551237e12a3a42c4438b97b"
   integrity sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q==
+
+mri@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 mrmime@^1.0.0:
   version "1.0.0"
@@ -11399,7 +11711,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11414,6 +11726,11 @@ property-information@^5.0.0, property-information@^5.3.0:
   integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
   dependencies:
     xtend "^4.0.0"
+
+property-information@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.1.1.tgz#5ca85510a3019726cb9afed4197b7b8ac5926a22"
+  integrity sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -11666,7 +11983,7 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1, react-is@^17.0.2:
+react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -11697,6 +12014,27 @@ react-magic-dropzone@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-magic-dropzone/-/react-magic-dropzone-1.0.1.tgz#bfd25b77b57e7a04aaef0a28910563b707ee54df"
   integrity sha1-v9Jbd7V+egSq7wookQVjtwfuVN8=
+
+react-markdown@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-8.0.1.tgz#683b5225fccbdd7eca76aa89b621894a317dd4d6"
+  integrity sha512-g78B0KtUk8oDRt59fX9SWhMikn3/qYcQW+aVMxdIulcjCNeecAZNOmR8uXy5p4bhbuPIS8gZly81bF4pAQWYXw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/prop-types" "^15.0.0"
+    "@types/unist" "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^2.0.0"
+    prop-types "^15.0.0"
+    property-information "^6.0.0"
+    react-is "^17.0.0"
+    remark-parse "^10.0.0"
+    remark-rehype "^10.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-object "^0.3.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+    vfile "^5.0.0"
 
 react-redux@^7.2.0:
   version "7.2.6"
@@ -12103,6 +12441,25 @@ remark-parse@8.0.3:
     vfile-location "^3.0.0"
     xtend "^4.0.1"
 
+remark-parse@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
+  integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    unified "^10.0.0"
+
+remark-rehype@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-10.1.0.tgz#32dc99d2034c27ecaf2e0150d22a6dcccd9a6279"
+  integrity sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-hast "^12.1.0"
+    unified "^10.0.0"
+
 remark-squeeze-paragraphs@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-4.0.0.tgz#76eb0e085295131c84748c8e43810159c5653ead"
@@ -12327,6 +12684,13 @@ rxjs@^7.1.0, rxjs@^7.5.1, rxjs@^7.5.4:
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
     tslib "^2.1.0"
+
+sade@^1.7.3:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+  dependencies:
+    mri "^1.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -12756,6 +13120,11 @@ space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
+
+space-separated-tokens@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz#43193cec4fb858a2ce934b7f98b7f2c18107098b"
+  integrity sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw==
 
 spawn-command@^0.0.2-1:
   version "0.0.2-1"
@@ -13483,6 +13852,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+trough@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
+  integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
+
 ts-jest@^27.0.6:
   version "27.1.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
@@ -13712,6 +14086,19 @@ unified@9.2.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
+unified@^10.0.0:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
+  integrity sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    bail "^2.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^5.0.0"
+
 unified@^8.4.2:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-8.4.2.tgz#13ad58b4a437faa2751a4a4c6a16f680c500fff1"
@@ -13749,20 +14136,44 @@ unist-builder@2.0.3, unist-builder@^2.0.0:
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
 
+unist-builder@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-3.0.0.tgz#728baca4767c0e784e1e64bb44b5a5a753021a04"
+  integrity sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
 unist-util-generated@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.6.tgz#5ab51f689e2992a472beb1b35f2ce7ff2f324d4b"
   integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
+
+unist-util-generated@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-2.0.0.tgz#86fafb77eb6ce9bfa6b663c3f5ad4f8e56a60113"
+  integrity sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==
 
 unist-util-is@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
   integrity sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
 
+unist-util-is@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
+  integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
+
 unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
   integrity sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==
+
+unist-util-position@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-4.0.2.tgz#1915816906a3503f3e40d65b6e4fe6d41845d2e3"
+  integrity sha512-Y6+plxR41dOLbyyqVDLuGWgXDmxdXslCSRYQkSDagBnOT9oFsQH0J8FzhirSklUEe0xZTT0WDnAE1gXPaDFljA==
+  dependencies:
+    "@types/unist" "^2.0.0"
 
 unist-util-remove-position@^2.0.0:
   version "2.0.1"
@@ -13785,6 +14196,13 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
+unist-util-stringify-position@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz#5c6aa07c90b1deffd9153be170dce628a869a447"
+  integrity sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
 unist-util-visit-parents@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz#65a6ce698f78a6b0f56aa0e88f13801886cdaef6"
@@ -13792,6 +14210,22 @@ unist-util-visit-parents@^3.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
+
+unist-util-visit-parents@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz#e83559a4ad7e6048a46b1bdb22614f2f3f4724f2"
+  integrity sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
+unist-util-visit-parents@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz#44bbc5d25f2411e7dfc5cecff12de43296aa8521"
+  integrity sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
 
 unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.1, unist-util-visit@^2.0.2, unist-util-visit@^2.0.3:
   version "2.0.3"
@@ -13801,6 +14235,24 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.1, unist-
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
+
+unist-util-visit@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-3.1.0.tgz#9420d285e1aee938c7d9acbafc8e160186dbaf7b"
+  integrity sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^4.0.0"
+
+unist-util-visit@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.0.tgz#f41e407a9e94da31594e6b1c9811c51ab0b3d8f5"
+  integrity sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.0.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"
@@ -13959,6 +14411,16 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uvu@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/uvu/-/uvu-0.5.3.tgz#3d83c5bc1230f153451877bfc7f4aea2392219ae"
+  integrity sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==
+  dependencies:
+    dequal "^2.0.0"
+    diff "^5.0.0"
+    kleur "^4.0.3"
+    sade "^1.7.3"
+
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
@@ -14055,6 +14517,14 @@ vfile-message@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
+vfile-message@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.1.2.tgz#a2908f64d9e557315ec9d7ea3a910f658ac05f7d"
+  integrity sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+
 vfile@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
@@ -14064,6 +14534,16 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vfile@^5.0.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.3.2.tgz#b499fbc50197ea50ad3749e9b60beb16ca5b7c54"
+  integrity sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description

In efforts to reduce `.mdx` file size by removing duplicated HTML and inline styles. The approach is to encapsulate JSX and any necessary styles into new Theme components, then simply importing them into `.mdx` files. This PR contains a small example (Request Params) as a POC, but a similar approach can potentially be extended further for other components i.e. Request Body, Response Schema, etc.

- Note: Added external library `react-markdown` to handle rendering of Markdown syntax in new theme components

### 🚧  In progress

- ~~Collapsible schema functionality~~
- ~~Markdown support for schema description~~

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
