### PR TITLE
Improvements/fixes to `allOf` schema support

### DIFF
--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -42,6 +42,7 @@
     "fs-extra": "^9.0.1",
     "js-yaml": "^4.1.0",
     "json-refs": "^3.0.15",
+    "json-schema-merge-allof": "^0.8.1",
     "lodash": "^4.17.20",
     "remark-admonitions": "^1.2.1",
     "webpack": "^5.61.0"

--- a/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi/src/markdown/createSchemaDetails.ts
@@ -133,15 +133,26 @@ function createRows({ schema }: RowsProps): string | undefined {
   // TODO: This can be a bit complicated types can be missmatched and there can be nested allOfs which need to be resolved before merging properties
   if (schema.allOf !== undefined) {
     const { properties, required } = resolveAllOf(schema.allOf);
-    return create("ul", {
-      className: "allOf",
-      children: Object.entries(properties).map(([key, val]) =>
-        createRow({
-          name: key,
-          schema: val,
-          required: Array.isArray(required) ? required.includes(key) : false,
-        })
-      ),
+    return create("div", {
+      children: [
+        create("span", {
+          className: "badge badge--info",
+          style: { marginBottom: "1rem" },
+          children: "allOf",
+        }),
+        create("ul", {
+          className: "allOf",
+          children: Object.entries(properties).map(([key, val]) =>
+            createRow({
+              name: key,
+              schema: val,
+              required: Array.isArray(required)
+                ? required.includes(key)
+                : false,
+            })
+          ),
+        }),
+      ],
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9101,7 +9101,7 @@ json-schema-compare@^0.2.2:
   dependencies:
     lodash "^4.17.4"
 
-json-schema-merge-allof@0.8.1:
+json-schema-merge-allof@0.8.1, json-schema-merge-allof@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz#ed2828cdd958616ff74f932830a26291789eaaf2"
   integrity sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==


### PR DESCRIPTION
## Description

Attempts to add improved support for nested `allOf` schemas by leveraging an external library named `json-schema-merge-allof` to handle resolving and merging nested schemas.

## Motivation and Context

Previous implementation did not handle nested `$refs` in `allOf` schema types.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
