### PR TITLE
[Hotfix]: Babel-loader import warnings

### DIFF
--- a/packages/docusaurus-theme-openapi/src/markdown/createDescription.ts
+++ b/packages/docusaurus-theme-openapi/src/markdown/createDescription.ts
@@ -1,0 +1,13 @@
+/* ============================================================================
+ * Copyright (c) Cloud Annotations
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+export function createDescription(description: string | undefined) {
+  if (!description) {
+    return "";
+  }
+  return `\n\n${description}\n\n`;
+}

--- a/packages/docusaurus-theme-openapi/src/markdown/schema.ts
+++ b/packages/docusaurus-theme-openapi/src/markdown/schema.ts
@@ -1,0 +1,115 @@
+/* ============================================================================
+ * Copyright (c) Cloud Annotations
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { SchemaObject } from "../types";
+
+function prettyName(schema: SchemaObject, circular?: boolean) {
+  if (schema.$ref) {
+    return schema.$ref.replace("#/components/schemas/", "") + circular
+      ? " (circular)"
+      : "";
+  }
+
+  if (schema.format) {
+    return schema.format;
+  }
+
+  if (schema.allOf) {
+    return "object";
+  }
+
+  if (schema.type === "object") {
+    return schema.xml?.name ?? schema.type;
+  }
+
+  return schema.title ?? schema.type;
+}
+
+export function getSchemaName(
+  schema: SchemaObject,
+  circular?: boolean
+): string {
+  if (schema.items) {
+    return prettyName(schema.items, circular) + "[]";
+  }
+
+  return prettyName(schema, circular) ?? "";
+}
+
+export function getQualifierMessage(schema?: SchemaObject): string | undefined {
+  // TODO:
+  // - maxItems
+  // - minItems
+  // - uniqueItems
+  // - maxProperties
+  // - minProperties
+  // - multipleOf
+  if (!schema) {
+    return undefined;
+  }
+
+  if (schema.items) {
+    return getQualifierMessage(schema.items);
+  }
+
+  let message = "**Possible values:** ";
+
+  let qualifierGroups = [];
+
+  if (schema.minLength || schema.maxLength) {
+    let lengthQualifier = "";
+    if (schema.minLength) {
+      lengthQualifier += `${schema.minLength} ≤ `;
+    }
+    lengthQualifier += "length";
+    if (schema.maxLength) {
+      lengthQualifier += ` ≤ ${schema.maxLength}`;
+    }
+    qualifierGroups.push(lengthQualifier);
+  }
+
+  if (
+    schema.minimum ||
+    schema.maximum ||
+    typeof schema.exclusiveMinimum === "number" ||
+    typeof schema.exclusiveMaximum === "number"
+  ) {
+    let minmaxQualifier = "";
+    if (typeof schema.exclusiveMinimum === "number") {
+      minmaxQualifier += `${schema.exclusiveMinimum} < `;
+    } else if (schema.minimum && !schema.exclusiveMinimum) {
+      minmaxQualifier += `${schema.minimum} ≤ `;
+    } else if (schema.minimum && schema.exclusiveMinimum === true) {
+      minmaxQualifier += `${schema.minimum} < `;
+    }
+    minmaxQualifier += "value";
+    if (typeof schema.exclusiveMaximum === "number") {
+      minmaxQualifier += ` < ${schema.exclusiveMaximum}`;
+    } else if (schema.maximum && !schema.exclusiveMaximum) {
+      minmaxQualifier += ` ≤ ${schema.maximum}`;
+    } else if (schema.maximum && schema.exclusiveMaximum === true) {
+      minmaxQualifier += ` < ${schema.maximum}`;
+    }
+    qualifierGroups.push(minmaxQualifier);
+  }
+
+  if (schema.pattern) {
+    qualifierGroups.push(
+      `Value must match regular expression \`${schema.pattern}\``
+    );
+  }
+
+  if (schema.enum) {
+    qualifierGroups.push(`[${schema.enum.map((e) => `\`${e}\``).join(", ")}]`);
+  }
+
+  if (qualifierGroups.length === 0) {
+    return undefined;
+  }
+
+  return message + qualifierGroups.join(", ");
+}

--- a/packages/docusaurus-theme-openapi/src/markdown/utils.ts
+++ b/packages/docusaurus-theme-openapi/src/markdown/utils.ts
@@ -1,0 +1,39 @@
+/* ============================================================================
+ * Copyright (c) Cloud Annotations
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+export type Children = string | undefined | (string | undefined)[];
+
+export type Props = Record<string, any> & { children?: Children };
+
+export function create(tag: string, props: Props): string {
+  const { children, ...rest } = props;
+
+  let propString = "";
+  for (const [key, value] of Object.entries(rest)) {
+    propString += ` ${key}={${JSON.stringify(value)}}`;
+  }
+
+  return `<${tag}${propString}>${render(children)}</${tag}>`;
+}
+
+export function guard<T>(
+  value: T | undefined,
+  cb: (value: T) => Children
+): string {
+  if (value) {
+    const children = cb(value);
+    return render(children);
+  }
+  return "";
+}
+
+export function render(children: Children): string {
+  if (Array.isArray(children)) {
+    return children.filter((c) => c !== undefined).join("");
+  }
+  return children ?? "";
+}

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -7,21 +7,16 @@
 
 import React from "react";
 
-import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/createDescription.js";
-import {
-  getQualifierMessage,
-  getSchemaName,
-} from "@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/schema.js";
 import ReactMarkdown from "react-markdown";
 
+import { createDescription } from "../../markdown/createDescription";
+import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
+import { guard } from "../../markdown/utils";
 import styles from "./styles.module.css";
-
-const MarkdownUtils = require("@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/utils");
 
 function ParamsItem({
   param: { description, example, examples, name, required, schema },
 }) {
-  const { guard } = MarkdownUtils;
   const renderSchemaName = guard(schema, (schema) => (
     <span className={styles.schemaName}> {getSchemaName(schema)}</span>
   ));

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -7,19 +7,21 @@
 
 import React from "react";
 
-import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
+import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/createDescription.js";
 import {
   getQualifierMessage,
   getSchemaName,
-} from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/schema";
-import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
+} from "@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/schema.js";
 import ReactMarkdown from "react-markdown";
 
 import styles from "./styles.module.css";
 
+const MarkdownUtils = require("@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/utils");
+
 function ParamsItem({
   param: { description, example, examples, name, required, schema },
 }) {
+  const { guard } = MarkdownUtils;
   const renderSchemaName = guard(schema, (schema) => (
     <span className={styles.schemaName}> {getSchemaName(schema)}</span>
   ));

--- a/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/ParamsItem/index.js
@@ -25,7 +25,6 @@ function ParamsItem({
     <strong className={styles.paramsRequired}> required</strong>
   ));
 
-  // TODO: getQualiferMessage() contains output in MD format, need to be able to handle formatting here?
   const renderSchema = guard(getQualifierMessage(schema), (message) => (
     <div>
       <ReactMarkdown children={createDescription(message)} />

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -7,12 +7,11 @@
 
 import React from "react";
 
-import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/createDescription.js";
 import ReactMarkdown from "react-markdown";
 
+import { createDescription } from "../../markdown/createDescription";
+import { guard } from "../../markdown/utils";
 import styles from "./styles.module.css";
-
-const MarkdownUtils = require("@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/utils");
 
 function SchemaItem({
   children: collapsibleSchemaContent,
@@ -23,7 +22,6 @@ function SchemaItem({
   schemaDescription,
   schemaName,
 }) {
-  const { guard } = MarkdownUtils;
   const renderRequired = guard(required, () => (
     <strong className={styles.required}> required</strong>
   ));

--- a/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi/src/theme/SchemaItem/index.js
@@ -7,11 +7,12 @@
 
 import React from "react";
 
-import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/createDescription";
-import { guard } from "@paloaltonetworks/docusaurus-plugin-openapi/src/markdown/utils";
+import { createDescription } from "@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/createDescription.js";
 import ReactMarkdown from "react-markdown";
 
 import styles from "./styles.module.css";
+
+const MarkdownUtils = require("@paloaltonetworks/docusaurus-plugin-openapi/lib/markdown/utils");
 
 function SchemaItem({
   children: collapsibleSchemaContent,
@@ -22,6 +23,7 @@ function SchemaItem({
   schemaDescription,
   schemaName,
 }) {
+  const { guard } = MarkdownUtils;
   const renderRequired = guard(required, () => (
     <strong className={styles.required}> required</strong>
   ));

--- a/packages/docusaurus-theme-openapi/src/types.ts
+++ b/packages/docusaurus-theme-openapi/src/types.ts
@@ -5,9 +5,66 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import type { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
+
 export interface ThemeConfig {
   api?: {
     proxy?: string;
     authPersistance?: false | "localStorage" | "sessionStorage";
   };
+}
+
+interface Map<T> {
+  [key: string]: T;
+}
+
+export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+export type SchemaObject = Omit<
+  JSONSchema,
+  | "type"
+  | "allOf"
+  | "oneOf"
+  | "anyOf"
+  | "not"
+  | "items"
+  | "properties"
+  | "additionalProperties"
+> & {
+  // OpenAPI specific overrides
+  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
+  allOf?: SchemaObject[];
+  oneOf?: SchemaObject[];
+  anyOf?: SchemaObject[];
+  not?: SchemaObject;
+  items?: SchemaObject;
+  properties?: Map<SchemaObject>;
+  additionalProperties?: boolean | SchemaObject;
+
+  // OpenAPI additions
+  nullable?: boolean;
+  discriminator?: DiscriminatorObject;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  xml?: XMLObject;
+  externalDocs?: ExternalDocumentationObject;
+  example?: any;
+  deprecated?: boolean;
+};
+
+export interface DiscriminatorObject {
+  propertyName: string;
+  mapping?: Map<string>;
+}
+
+export interface XMLObject {
+  name?: string;
+  namespace?: string;
+  prefix?: string;
+  attribute?: boolean;
+  wrapped?: boolean;
+}
+
+export interface ExternalDocumentationObject {
+  description?: string;
+  url: string;
 }


### PR DESCRIPTION
## Description

Fix warnings when importing `guard()` into `SchemaItem` and `ParamsItem`. 
- The following TS modules and types were copied over from `plugin-openapi` to `theme-openapi`

  - `createDescription()`
  - `guard()`
  - `getQualifierMessage()`
  - `getSchemaName()`
  - `SchemaObject` type

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

### Before 
![Screen Shot 2022-04-01 at 3 36 58 PM](https://user-images.githubusercontent.com/48506502/161350859-ec1f1bbf-78c0-4d1e-aba4-df5d62da8be8.png)

### After
![image](https://user-images.githubusercontent.com/48506502/161350645-a2a88bd5-ff96-4c8c-ab60-91e8df02fc8f.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
