### PR TITLE
[Experimental] Enable prev/next for beforeApiDocs items

### DIFF
--- a/packages/docusaurus-plugin-openapi/src/docs/docs.ts
+++ b/packages/docusaurus-plugin-openapi/src/docs/docs.ts
@@ -107,12 +107,7 @@ export async function processDocFiles(
       type: "doc" as "doc", // TODO: fix this
       id: frontMatter.id ?? "",
       unversionedId: frontMatter.id ?? "",
-      title:
-        frontMatter.sidebar_label ??
-        frontMatter.title ??
-        contentTitle ??
-        frontMatter.id ??
-        "",
+      title: frontMatter.title ?? contentTitle ?? frontMatter.id ?? "",
       description: frontMatter.description ?? excerpt ?? "",
       slug: slug,
       frontMatter: frontMatter,
@@ -157,7 +152,10 @@ export async function processDocFiles(
 
     if (prev) {
       current.previous = {
-        title: prev.title,
+        title:
+          (prev.frontMatter.pagination_label as string) ??
+          (prev.frontMatter.sidebar_label as string) ??
+          prev.title,
         permalink: normalizeUrl([
           options.baseUrl,
           options.routeBasePath,
@@ -168,7 +166,10 @@ export async function processDocFiles(
 
     if (next) {
       current.next = {
-        title: next.title,
+        title:
+          (next.frontMatter.pagination_label as string) ??
+          (next.frontMatter.sidebar_label as string) ??
+          next.title,
         permalink: normalizeUrl([
           options.baseUrl,
           options.routeBasePath,

--- a/packages/docusaurus-plugin-openapi/src/docs/docs.ts
+++ b/packages/docusaurus-plugin-openapi/src/docs/docs.ts
@@ -107,7 +107,12 @@ export async function processDocFiles(
       type: "doc" as "doc", // TODO: fix this
       id: frontMatter.id ?? "",
       unversionedId: frontMatter.id ?? "",
-      title: frontMatter.title ?? contentTitle ?? frontMatter.id ?? "",
+      title:
+        frontMatter.sidebar_label ??
+        frontMatter.title ??
+        contentTitle ??
+        frontMatter.id ??
+        "",
       description: frontMatter.description ?? excerpt ?? "",
       slug: slug,
       frontMatter: frontMatter,

--- a/packages/docusaurus-plugin-openapi/src/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/index.ts
@@ -70,11 +70,20 @@ export default function pluginOpenAPI(
       });
       try {
         const openapiFiles = await readOpenapiFiles(contentPath, {});
-        const loadedApi = await processOpenapiFiles(openapiFiles, {
+        const loadedApi = await processOpenapiFiles(loadedDocs, openapiFiles, {
           baseUrl,
           routeBasePath,
           siteDir: context.siteDir,
         });
+
+        // Set item.next on last doc item
+        if (loadedDocs.length > 0) {
+          loadedDocs[loadedDocs.length - 1].next = {
+            title: loadedApi[0].title,
+            permalink: loadedApi[0].permalink,
+          };
+        }
+
         return { loadedApi, loadedDocs };
       } catch (e) {
         console.error(chalk.red(`Loading of api failed for "${contentPath}"`));

--- a/packages/docusaurus-plugin-openapi/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi/src/openapi/openapi.ts
@@ -22,7 +22,12 @@ import yaml from "js-yaml";
 import JsonRefs from "json-refs";
 import { kebabCase } from "lodash";
 
-import { ApiMetadata, ApiPageMetadata, InfoPageMetadata } from "../types";
+import {
+  ApiMetadata,
+  ApiPageMetadata,
+  InfoPageMetadata,
+  DocPageMetadata,
+} from "../types";
 import { sampleFromSchema } from "./createExample";
 import { OpenApiObject, OpenApiObjectWithRef, TagObject } from "./types";
 
@@ -250,6 +255,7 @@ export async function readOpenapiFiles(
 }
 
 export async function processOpenapiFiles(
+  beforeApiItems: DocPageMetadata[],
   files: OpenApiFiles[],
   options: {
     baseUrl: string;
@@ -289,7 +295,13 @@ export async function processOpenapiFiles(
 
   for (let i = 0; i < items.length; i++) {
     const current = items[i];
-    const prev = items[i - 1];
+    let prev;
+    if (i === 0) {
+      // Set item.prev to last doc item
+      prev = beforeApiItems[beforeApiItems.length - 1];
+    } else {
+      prev = items[i - 1];
+    }
     const next = items[i + 1];
 
     current.permalink = normalizeUrl([
@@ -320,7 +332,6 @@ export async function processOpenapiFiles(
       };
     }
   }
-
   return items;
 }
 


### PR DESCRIPTION
## Description

Adds prev/next button support for `beforeApiDocs` items.

## Motivation and Context

Improves navigation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
