### PR TITLE
[Cleanup]: Remove useMonaco hook

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/VSCode/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/VSCode/index.tsx
@@ -24,12 +24,8 @@ function VSCode({ value, language, onChange }: Props) {
   const { isDarkTheme } = useColorMode();
 
   useEffect(() => {
-    // do conditional chaining
+    // Ensure monaco instance is loaded
     monaco?.languages.typescript.javascriptDefaults.setEagerModelSync(true);
-    // or make sure that it exists by other ways
-    if (monaco) {
-      console.log("here is the monaco instance:", monaco);
-    }
   }, [monaco]);
 
   function handleEditorWillMount(monaco: any) {

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/VSCode/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/VSCode/index.tsx
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
 import { useColorMode } from "@docusaurus/theme-common";
-import Editor, { useMonaco } from "@monaco-editor/react";
+import Editor, { Monaco } from "@monaco-editor/react";
 
 import styles from "./styles.module.css";
 
@@ -20,15 +20,9 @@ interface Props {
 
 function VSCode({ value, language, onChange }: Props) {
   const [focused, setFocused] = useState(false);
-  const monaco = useMonaco();
   const { isDarkTheme } = useColorMode();
 
-  useEffect(() => {
-    // Ensure monaco instance is loaded
-    monaco?.languages.typescript.javascriptDefaults.setEagerModelSync(true);
-  }, [monaco]);
-
-  function handleEditorWillMount(monaco: any) {
+  function handleEditorWillMount(monaco: Monaco) {
     const styles = getComputedStyle(document.documentElement);
 
     function getColor(property: string) {
@@ -76,7 +70,7 @@ function VSCode({ value, language, onChange }: Props) {
     const LIGHT_BACKGROUND = getColor(
       "--openapi-monaco-background-color-light"
     );
-    const LIGHT_BRIGHT = getColor("--openapi-code-bright-light");
+    const LIGHT_BRIGHT = getColor("--openapi-code-blue-light");
     const LIGHT_DIM = getColor("--openapi-code-dim-light");
     const LIGHT_BLUE = getColor("--openapi-code-blue-light");
     const LIGHT_GREEN = getColor("--openapi-code-green-light");

--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/VSCode/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/VSCode/index.tsx
@@ -70,7 +70,7 @@ function VSCode({ value, language, onChange }: Props) {
     const LIGHT_BACKGROUND = getColor(
       "--openapi-monaco-background-color-light"
     );
-    const LIGHT_BRIGHT = getColor("--openapi-code-blue-light");
+    const LIGHT_BRIGHT = getColor("--openapi-code-bright-light");
     const LIGHT_DIM = getColor("--openapi-code-dim-light");
     const LIGHT_BLUE = getColor("--openapi-code-blue-light");
     const LIGHT_GREEN = getColor("--openapi-code-green-light");

--- a/packages/docusaurus-theme-openapi/src/theme/ApiItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiItem/styles.module.css
@@ -1,3 +1,7 @@
+:root {
+  --openapi-required: var(--ifm-color-danger);
+}
+
 .apiItemContainer article > *:first-child,
 .apiItemContainer header + * {
   margin-top: 0;


### PR DESCRIPTION
## Description

- Remove `useMonaco()` hook and revert to original import of `Monaco` type. CORS issue was caused by empty string values being passed into the editor. _Issue resolved in #48_
- Add `--openapi-required` variable to style `required` schema fields

## Motivation and Context

Using the `useMonaco()` hook alongside with `Editor` caused a duplicate module warning in the browser console.
![Screen Shot 2022-04-14 at 11 38 35 AM](https://user-images.githubusercontent.com/48506502/163473368-144c0bf5-dc03-4616-b70f-2302617f39d7.png)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/48506502/163473539-b8a8c67c-e5c4-4bd8-9768-3cbc7c5f2819.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
